### PR TITLE
feat(backend): fix http method, allow description generation.

### DIFF
--- a/scholarsync-backend/.env.example
+++ b/scholarsync-backend/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=<place-key-here>

--- a/scholarsync-backend/.gitignore
+++ b/scholarsync-backend/.gitignore
@@ -18,3 +18,5 @@ Cargo.lock
 *.pdb
 
 # End of https://www.toptal.com/developers/gitignore/api/rust
+
+.env

--- a/scholarsync-backend/Cargo.toml
+++ b/scholarsync-backend/Cargo.toml
@@ -5,5 +5,7 @@ edition = "2024"
 
 [dependencies]
 actix-web = "4"
+async-openai = { version = "0.28.1", features = ["byot"] }
+dotenv = "0.15.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/scholarsync-backend/data.json
+++ b/scholarsync-backend/data.json
@@ -1,5 +1,93 @@
 [
   {
+    "id": 3,
+    "name": "Dr. Olivia Brown",
+    "dept": "Department of Business",
+    "desc": "Studying AI's impact on market trends.",
+    "papers": [
+      {
+        "id": 0,
+        "title": "Machine Learning in Finance"
+      },
+      {
+        "id": 1,
+        "title": "Predictive Analytics for Stock Markets"
+      },
+      {
+        "id": 2,
+        "title": "AI and Consumer Behavior Trends"
+      },
+      {
+        "id": 3,
+        "title": "Supply Chain Optimization with AI"
+      }
+    ]
+  },
+  {
+    "id": 0,
+    "name": "Dr. Foo Bar",
+    "dept": "Department of Computer Science",
+    "desc": "Testing to see if this can be changed.",
+    "papers": [
+      {
+        "id": 0,
+        "title": "Machine Learning for Research Discovery"
+      },
+      {
+        "id": 1,
+        "title": "AI in Academic Collaboration"
+      },
+      {
+        "id": 2,
+        "title": "Semantic Search in Research Papers"
+      },
+      {
+        "id": 3,
+        "title": "Deep Learning for Text Classification"
+      },
+      {
+        "id": 4,
+        "title": "Some test paper being added."
+      },
+      {
+        "id": 5,
+        "title": "Some test paper being added."
+      },
+      {
+        "id": 6,
+        "title": "Some test paper being added."
+      },
+      {
+        "id": 7,
+        "title": "Some test paper being added."
+      }
+    ]
+  },
+  {
+    "id": 1,
+    "name": "Dr. Alice Johnson",
+    "dept": "Department of AI",
+    "desc": "This professor's research interests focus on the application of neural networks in academic settings, including matching and citation analysis, as well as advancements in NLP through transformer models and automated summarization of research papers.",
+    "papers": [
+      {
+        "id": 0,
+        "title": "Neural Networks for Academic Matching"
+      },
+      {
+        "id": 1,
+        "title": "AI-powered Citation Analysis"
+      },
+      {
+        "id": 2,
+        "title": "Automated Research Paper Summarization"
+      },
+      {
+        "id": 3,
+        "title": "Transformers and Their Impact on NLP"
+      }
+    ]
+  },
+  {
     "id": 8,
     "name": "Dr. Benjamin Carter",
     "dept": "Department of Cybersecurity",
@@ -20,6 +108,102 @@
       {
         "id": 3,
         "title": "Privacy-Preserving Machine Learning Models"
+      }
+    ]
+  },
+  {
+    "id": 7,
+    "name": "Dr. Emily White",
+    "dept": "Department of Education",
+    "desc": "Using AI to enhance online learning experiences.",
+    "papers": [
+      {
+        "id": 0,
+        "title": "AI-powered Personalized Learning Platforms"
+      },
+      {
+        "id": 1,
+        "title": "Using Chatbots in Online Education"
+      },
+      {
+        "id": 2,
+        "title": "Machine Learning for Student Performance Prediction"
+      },
+      {
+        "id": 3,
+        "title": "AI-driven Automated Grading Systems"
+      }
+    ]
+  },
+  {
+    "id": 9,
+    "name": "Dr. Victoria Wilson",
+    "dept": "Department of Robotics",
+    "desc": "Building AI-powered robotic systems.",
+    "papers": [
+      {
+        "id": 0,
+        "title": "Autonomous Robots and AI"
+      },
+      {
+        "id": 1,
+        "title": "Reinforcement Learning in Robotics"
+      },
+      {
+        "id": 2,
+        "title": "Human-Robot Interaction with AI"
+      },
+      {
+        "id": 3,
+        "title": "AI-driven Robotic Surgery"
+      }
+    ]
+  },
+  {
+    "id": 5,
+    "name": "Dr. Sophia Martinez",
+    "dept": "Department of Physics",
+    "desc": "Using AI for quantum mechanics research.",
+    "papers": [
+      {
+        "id": 0,
+        "title": "Quantum Computing with AI"
+      },
+      {
+        "id": 1,
+        "title": "Simulating Quantum Particles with Machine Learning"
+      },
+      {
+        "id": 2,
+        "title": "AI and Particle Physics"
+      },
+      {
+        "id": 3,
+        "title": "Superconductors and AI-based Prediction Models"
+      }
+    ]
+  },
+  {
+    "id": 4,
+    "name": "Dr. Ethan Taylor",
+    "dept": "Department of Humanities",
+    "desc": "Investigating AI's role in creative industries.",
+    "papers": [
+      {
+        "id": 0,
+        "title": "Natural Language Processing in Literature"
+      },
+      {
+        "id": 1,
+        "title": "AI and Human Creativity"
+      },
+      {
+        "id": 2,
+        "title": "Automated Journalism and AI Ethics"
+      },
+      {
+        "id": 3,
+        "title": "AI-generated Art and Copyright Issues"
       }
     ]
   },
@@ -51,30 +235,6 @@
       {
         "id": 3,
         "title": "AI-powered Space Exploration"
-      }
-    ]
-  },
-  {
-    "id": 7,
-    "name": "Dr. Emily White",
-    "dept": "Department of Education",
-    "desc": "Using AI to enhance online learning experiences.",
-    "papers": [
-      {
-        "id": 0,
-        "title": "AI-powered Personalized Learning Platforms"
-      },
-      {
-        "id": 1,
-        "title": "Using Chatbots in Online Education"
-      },
-      {
-        "id": 2,
-        "title": "Machine Learning for Student Performance Prediction"
-      },
-      {
-        "id": 3,
-        "title": "AI-driven Automated Grading Systems"
       }
     ]
   },
@@ -123,166 +283,6 @@
       {
         "id": 3,
         "title": "Predicting Disease Progression with AI"
-      }
-    ]
-  },
-  {
-    "id": 5,
-    "name": "Dr. Sophia Martinez",
-    "dept": "Department of Physics",
-    "desc": "Using AI for quantum mechanics research.",
-    "papers": [
-      {
-        "id": 0,
-        "title": "Quantum Computing with AI"
-      },
-      {
-        "id": 1,
-        "title": "Simulating Quantum Particles with Machine Learning"
-      },
-      {
-        "id": 2,
-        "title": "AI and Particle Physics"
-      },
-      {
-        "id": 3,
-        "title": "Superconductors and AI-based Prediction Models"
-      }
-    ]
-  },
-  {
-    "id": 9,
-    "name": "Dr. Victoria Wilson",
-    "dept": "Department of Robotics",
-    "desc": "Building AI-powered robotic systems.",
-    "papers": [
-      {
-        "id": 0,
-        "title": "Autonomous Robots and AI"
-      },
-      {
-        "id": 1,
-        "title": "Reinforcement Learning in Robotics"
-      },
-      {
-        "id": 2,
-        "title": "Human-Robot Interaction with AI"
-      },
-      {
-        "id": 3,
-        "title": "AI-driven Robotic Surgery"
-      }
-    ]
-  },
-  {
-    "id": 1,
-    "name": "Dr. Alice Johnson",
-    "dept": "Department of AI",
-    "desc": "Exploring neural networks and their applications in academia.",
-    "papers": [
-      {
-        "id": 0,
-        "title": "Neural Networks for Academic Matching"
-      },
-      {
-        "id": 1,
-        "title": "AI-powered Citation Analysis"
-      },
-      {
-        "id": 2,
-        "title": "Automated Research Paper Summarization"
-      },
-      {
-        "id": 3,
-        "title": "Transformers and Their Impact on NLP"
-      }
-    ]
-  },
-  {
-    "id": 4,
-    "name": "Dr. Ethan Taylor",
-    "dept": "Department of Humanities",
-    "desc": "Investigating AI's role in creative industries.",
-    "papers": [
-      {
-        "id": 0,
-        "title": "Natural Language Processing in Literature"
-      },
-      {
-        "id": 1,
-        "title": "AI and Human Creativity"
-      },
-      {
-        "id": 2,
-        "title": "Automated Journalism and AI Ethics"
-      },
-      {
-        "id": 3,
-        "title": "AI-generated Art and Copyright Issues"
-      }
-    ]
-  },
-  {
-    "id": 0,
-    "name": "Dr. Foo Bar",
-    "dept": "Department of Computer Science",
-    "desc": "Testing to see if this can be changed.",
-    "papers": [
-      {
-        "id": 0,
-        "title": "Machine Learning for Research Discovery"
-      },
-      {
-        "id": 1,
-        "title": "AI in Academic Collaboration"
-      },
-      {
-        "id": 2,
-        "title": "Semantic Search in Research Papers"
-      },
-      {
-        "id": 3,
-        "title": "Deep Learning for Text Classification"
-      },
-      {
-        "id": 4,
-        "title": "Some test paper being added."
-      },
-      {
-        "id": 5,
-        "title": "Some test paper being added."
-      },
-      {
-        "id": 6,
-        "title": "Some test paper being added."
-      },
-      {
-        "id": 7,
-        "title": "Some test paper being added."
-      }
-    ]
-  },
-  {
-    "id": 3,
-    "name": "Dr. Olivia Brown",
-    "dept": "Department of Business",
-    "desc": "Studying AI's impact on market trends.",
-    "papers": [
-      {
-        "id": 0,
-        "title": "Machine Learning in Finance"
-      },
-      {
-        "id": 1,
-        "title": "Predictive Analytics for Stock Markets"
-      },
-      {
-        "id": 2,
-        "title": "AI and Consumer Behavior Trends"
-      },
-      {
-        "id": 3,
-        "title": "Supply Chain Optimization with AI"
       }
     ]
   }

--- a/scholarsync-backend/src/chatgpt.rs
+++ b/scholarsync-backend/src/chatgpt.rs
@@ -1,0 +1,36 @@
+use serde_json::{Value, json};
+
+const DESC_PROMPT: &str = "Please generate a summary of research interests for
+this professor from their list of paper titles. If a description cannot be
+determined, please return a dummy description. Descriptions should be at most
+256 characters.";
+
+pub struct ModelRequest(pub String);
+
+impl ModelRequest {
+    pub async fn make(&self) -> Result<String, String> {
+        let client = async_openai::Client::new();
+        let res: Value = client
+            .chat()
+            .create_byot(json!({
+                "messages": [
+                    {
+                        "role": "developer",
+                        "content": DESC_PROMPT
+                    },
+                    {
+                        "role": "user",
+                        "content": self.0
+                    }
+                ],
+                "model": "gpt-4o-mini",
+                "store": false
+            }))
+            .await
+            .map_err(|e| format!("Error making request to ChatGPT: {e}"))?;
+        Ok(res["choices"][0]["message"]["content"]
+            .to_string()
+            .trim_matches('"')
+            .to_string())
+    }
+}

--- a/scholarsync-backend/src/dataset.rs
+++ b/scholarsync-backend/src/dataset.rs
@@ -2,6 +2,8 @@ use std::{collections::HashMap, io::Write};
 
 use serde::{Deserialize, Serialize};
 
+use crate::chatgpt::ModelRequest;
+
 /// Contains information about a `Paper` authored by a `Professor`.
 #[derive(Deserialize, Serialize, Clone)]
 pub struct Paper {
@@ -17,6 +19,20 @@ pub struct Professor {
     pub dept: String,
     pub desc: String,
     pub papers: Vec<Paper>,
+}
+
+impl Professor {
+    pub async fn generate_description(&mut self) -> Result<String, String> {
+        let papers = self
+            .papers
+            .iter()
+            .map(|p| p.title.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let desc = ModelRequest(papers).make().await?;
+        self.desc = desc.clone();
+        Ok(desc)
+    }
 }
 
 /// Stores `Professor`s, indexed by each of their IDs.

--- a/scholarsync-backend/src/main.rs
+++ b/scholarsync-backend/src/main.rs
@@ -3,14 +3,16 @@ use std::sync::RwLock;
 use actix_web::{App, HttpServer, web::Data};
 use routes::{
     RouteHandlerData, add_paper, add_professor, delete_paper, delete_professor, edit_professor,
-    get_all_professors, get_papers, get_professor,
+    get_all_professors, get_description, get_papers, get_professor,
 };
 
+mod chatgpt;
 mod dataset;
 mod routes;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    dotenv::dotenv().expect("Cannot get .env variables");
     let data: RouteHandlerData = Data::new(RwLock::new(dataset::load_dataset("data.json")));
 
     HttpServer::new(move || {
@@ -24,6 +26,7 @@ async fn main() -> std::io::Result<()> {
             .service(get_papers)
             .service(add_paper)
             .service(delete_paper)
+            .service(get_description)
     })
     .bind(("0.0.0.0", 8080))?
     .run()


### PR DESCRIPTION
- Method has been changed to `PATCH` for route `/api/professors/{prof_id}`.
- Descriptions may now be generated by ChatGPT if a `GET` request made to route `/api/professors/{prof_id}/description`. This description is saved to the professor and to the JSON file.